### PR TITLE
Feature: Create a listener for recent apps thumbnail hiding customization

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,13 +10,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/App.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/App.kt
@@ -1,76 +1,11 @@
 package co.nimblehq.recentapps.thumbnailhiding
 
-import android.app.Activity
 import android.app.Application
-import android.os.Bundle
-import android.view.WindowManager
 
 class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        registerActivityLifecycleCallbacks(AppLifecycleTracker())
-    }
-}
-
-class AppLifecycleTracker : Application.ActivityLifecycleCallbacks {
-
-    private var hardwareKeyWatcher: HardwareKeyWatcher? = null
-
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-    }
-
-    override fun onActivityStarted(activity: Activity) {
-        hardwareKeyWatcher = HardwareKeyWatcher(activity).apply {
-            setOnHardwareKeysPressedListenerListener(object :
-                HardwareKeyWatcher.OnHardwareKeysPressedListener {
-                override fun onHomePressed() {
-                    activity.showOrHideAppRecentThumbnail(false)
-                }
-
-                override fun onRecentAppsPressed() {
-                    activity.showOrHideAppRecentThumbnail(false)
-                }
-            })
-            startWatch()
-        }
-    }
-
-    override fun onActivityResumed(activity: Activity) {
-        activity.showOrHideAppRecentThumbnail(true)
-    }
-
-    override fun onActivityPaused(activity: Activity) {
-        /*
-         * Fix hide app recent for 2 cases:
-         * - pulldown notification > settings > recent
-         * - messenger chathead > profile in fullscreen > recent
-         * - Xiaomi accessibility button > recent
-         */
-        activity.showOrHideAppRecentThumbnail(false)
-    }
-
-    override fun onActivityStopped(activity: Activity) {
-        hardwareKeyWatcher?.stopWatch()
-        hardwareKeyWatcher = null
-    }
-
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-    }
-
-    override fun onActivityDestroyed(activity: Activity) {
-    }
-
-    private fun Activity.showOrHideAppRecentThumbnail(show: Boolean) {
-        if (show) {
-            window.clearFlags(
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        } else {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
+        registerActivityLifecycleCallbacks(RecentAppsThumbnailHidingLifecycleTracker())
     }
 }

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
@@ -1,5 +1,6 @@
 package co.nimblehq.recentapps.thumbnailhiding
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.View.GONE
 import android.view.View.VISIBLE
@@ -13,7 +14,10 @@ class MainActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
         setContentView(R.layout.activity_main)
     }
 
-    override fun onRecentAppsTriggered(inRecentAppsMode: Boolean) {
+    override fun onRecentAppsTriggered(
+        activity: Activity,
+        inRecentAppsMode: Boolean
+    ) {
         ivRecentAppsLogo.visibility = if (inRecentAppsMode) VISIBLE else GONE
     }
 }

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
@@ -1,12 +1,19 @@
 package co.nimblehq.recentapps.thumbnailhiding
 
 import android.os.Bundle
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.activity_main.*
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    override fun onRecentAppsTriggered(inRecentAppsMode: Boolean) {
+        ivRecentAppsLogo.visibility = if (inRecentAppsMode) VISIBLE else GONE
     }
 }

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/SplashActivity.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/SplashActivity.kt
@@ -1,0 +1,23 @@
+package co.nimblehq.recentapps.thumbnailhiding
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import kotlinx.android.synthetic.main.activity_main.*
+
+class SplashActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_splash)
+    }
+
+    override fun onPostCreate(savedInstanceState: Bundle?) {
+        super.onPostCreate(savedInstanceState)
+
+        ivRecentAppsLogo.postDelayed({
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+        }, 2000L)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,4 +23,13 @@
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
 
+    <ImageView
+        android:id="@+id/ivRecentAppsLogo"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#080808"
+        android:scaleType="centerInside"
+        android:src="@mipmap/ic_launcher"
+        android:visibility="gone" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#080808"
+    tools:context=".MainActivity">
+
+    <ImageView
+        android:id="@+id/ivRecentAppsLogo"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#080808"
+        android:scaleType="centerInside"
+        android:src="@mipmap/ic_launcher" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/HardwareKeyWatcher.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/HardwareKeyWatcher.java
@@ -56,7 +56,7 @@ public class HardwareKeyWatcher {
             if (Intent.ACTION_CLOSE_SYSTEM_DIALOGS.equals(action)) {
                 String reason = intent.getStringExtra(SYSTEM_DIALOG_REASON_KEY);
                 if (reason != null) {
-                    Log.e(TAG, "action:" + action + ",reason:" + reason);
+                    Log.i(TAG, "action:" + action + ", reason:" + reason);
                     if (mListener != null) {
                         switch (reason) {
                             case SYSTEM_DIALOG_REASON_HOME_KEY:

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/HardwareKeyWatcher.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/HardwareKeyWatcher.java
@@ -33,14 +33,20 @@ public class HardwareKeyWatcher {
 
     public void startWatch() {
         if (mReceiver != null) {
+            Log.d(TAG, "startWatch on " + mContext);
             mContext.registerReceiver(mReceiver, mFilter);
         }
     }
 
     public void stopWatch() {
         if (mReceiver != null) {
+            Log.d(TAG, "stopWatch on " + mContext);
             mContext.unregisterReceiver(mReceiver);
         }
+    }
+
+    public Context getContext() {
+        return mContext;
     }
 
     class InnerReceiver extends BroadcastReceiver {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -12,6 +12,10 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     }
 
     override fun onActivityStarted(activity: Activity) {
+        if (hardwareKeyWatcher != null && hardwareKeyWatcher?.context != activity) {
+            hardwareKeyWatcher?.stopWatch()
+            hardwareKeyWatcher = null
+        }
         hardwareKeyWatcher = HardwareKeyWatcher(activity).apply {
             setOnHardwareKeysPressedListenerListener(object :
                 HardwareKeyWatcher.OnHardwareKeysPressedListener {
@@ -42,8 +46,10 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     }
 
     override fun onActivityStopped(activity: Activity) {
-        hardwareKeyWatcher?.stopWatch()
-        hardwareKeyWatcher = null
+        if (hardwareKeyWatcher != null && hardwareKeyWatcher?.context == activity) {
+            hardwareKeyWatcher?.stopWatch()
+            hardwareKeyWatcher = null
+        }
     }
 
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -12,7 +12,7 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     }
 
     override fun onActivityStarted(activity: Activity) {
-        if (hardwareKeyWatcher != null && hardwareKeyWatcher?.context != activity) {
+        if (hardwareKeyWatcher?.context != activity) {
             hardwareKeyWatcher?.stopWatch()
             hardwareKeyWatcher = null
         }
@@ -46,7 +46,7 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     }
 
     override fun onActivityStopped(activity: Activity) {
-        if (hardwareKeyWatcher != null && hardwareKeyWatcher?.context == activity) {
+        if (hardwareKeyWatcher?.context == activity) {
             hardwareKeyWatcher?.stopWatch()
             hardwareKeyWatcher = null
         }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -1,0 +1,68 @@
+package co.nimblehq.recentapps.thumbnailhiding
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.view.WindowManager
+
+class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleCallbacks {
+
+    private var hardwareKeyWatcher: HardwareKeyWatcher? = null
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        hardwareKeyWatcher = HardwareKeyWatcher(activity).apply {
+            setOnHardwareKeysPressedListenerListener(object :
+                HardwareKeyWatcher.OnHardwareKeysPressedListener {
+                override fun onHomePressed() {
+                    activity.showOrHideAppRecentThumbnail(false)
+                }
+
+                override fun onRecentAppsPressed() {
+                    activity.showOrHideAppRecentThumbnail(false)
+                }
+            })
+            startWatch()
+        }
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        activity.showOrHideAppRecentThumbnail(true)
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        /*
+         * Fix hide app recent for 2 cases:
+         * - pulldown notification > settings > recent
+         * - messenger chathead > profile in fullscreen > recent
+         * - Xiaomi accessibility button > recent
+         */
+        activity.showOrHideAppRecentThumbnail(false)
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        hardwareKeyWatcher?.stopWatch()
+        hardwareKeyWatcher = null
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+    }
+
+    private fun Activity.showOrHideAppRecentThumbnail(show: Boolean) {
+        if (show) {
+            window.clearFlags(
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        } else {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+    }
+}

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -3,7 +3,6 @@ package co.nimblehq.recentapps.thumbnailhiding
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import android.view.WindowManager
 
 class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleCallbacks {
 
@@ -55,21 +54,11 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
 
     private fun Activity.triggerRecentAppsMode(inRecentAppsMode: Boolean) {
         when (val activity = this) {
-            is RecentAppsThumbnailHidingListener -> activity.onRecentAppsTriggered(inRecentAppsMode)
-            else -> activity.showOrHideAppRecentThumbnail(inRecentAppsMode)
-        }
-    }
-
-    private fun Activity.showOrHideAppRecentThumbnail(inRecentAppsMode: Boolean) {
-        if (inRecentAppsMode) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        } else {
-            window.clearFlags(
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
+            is RecentAppsThumbnailHidingListener ->
+                activity.onRecentAppsTriggered(
+                    activity,
+                    inRecentAppsMode
+                )
         }
     }
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -17,11 +17,11 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
             setOnHardwareKeysPressedListenerListener(object :
                 HardwareKeyWatcher.OnHardwareKeysPressedListener {
                 override fun onHomePressed() {
-                    activity.showOrHideAppRecentThumbnail(false)
+                    activity.triggerRecentAppsMode(true)
                 }
 
                 override fun onRecentAppsPressed() {
-                    activity.showOrHideAppRecentThumbnail(false)
+                    activity.triggerRecentAppsMode(true)
                 }
             })
             startWatch()
@@ -29,7 +29,7 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     }
 
     override fun onActivityResumed(activity: Activity) {
-        activity.showOrHideAppRecentThumbnail(true)
+        activity.triggerRecentAppsMode(false)
     }
 
     override fun onActivityPaused(activity: Activity) {
@@ -39,7 +39,7 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
          * - messenger chathead > profile in fullscreen > recent
          * - Xiaomi accessibility button > recent
          */
-        activity.showOrHideAppRecentThumbnail(false)
+        activity.triggerRecentAppsMode(true)
     }
 
     override fun onActivityStopped(activity: Activity) {
@@ -53,14 +53,21 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     override fun onActivityDestroyed(activity: Activity) {
     }
 
-    private fun Activity.showOrHideAppRecentThumbnail(show: Boolean) {
-        if (show) {
-            window.clearFlags(
+    private fun Activity.triggerRecentAppsMode(inRecentAppsMode: Boolean) {
+        when (val activity = this) {
+            is RecentAppsThumbnailHidingListener -> activity.onRecentAppsTriggered(inRecentAppsMode)
+            else -> activity.showOrHideAppRecentThumbnail(inRecentAppsMode)
+        }
+    }
+
+    private fun Activity.showOrHideAppRecentThumbnail(inRecentAppsMode: Boolean) {
+        if (inRecentAppsMode) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE
             )
         } else {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
+            window.clearFlags(
                 WindowManager.LayoutParams.FLAG_SECURE
             )
         }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
@@ -1,0 +1,6 @@
+package co.nimblehq.recentapps.thumbnailhiding
+
+interface RecentAppsThumbnailHidingListener {
+
+    fun onRecentAppsTriggered(inRecentAppsMode: Boolean)
+}

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
@@ -1,6 +1,32 @@
 package co.nimblehq.recentapps.thumbnailhiding
 
+import android.app.Activity
+import android.view.WindowManager
+
 interface RecentAppsThumbnailHidingListener {
 
-    fun onRecentAppsTriggered(inRecentAppsMode: Boolean)
+    /**
+     * Default implementation: enable app thumbnail hiding with `FLAG_SECURE` flag
+     * Override to implement custom app thumbnail hiding
+     * Override with empty body or ignore interface implementation to ignore app thumbnail hiding
+     */
+    fun onRecentAppsTriggered(
+        activity: Activity,
+        inRecentAppsMode: Boolean
+    ) {
+        activity.showOrHideRecentAppThumbnail(inRecentAppsMode)
+    }
+
+    private fun Activity.showOrHideRecentAppThumbnail(inRecentAppsMode: Boolean) {
+        if (inRecentAppsMode) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        } else {
+            window.clearFlags(
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+    }
 }


### PR DESCRIPTION
## What happened 🤔
The first implementation of `HardwareKeyWatcher` has been finished with default `FLAG_SECURE` using via an `AppLifecycleTracker`. We need to bring this lifecycle into the lib + create a listener for recent apps thumbnail hiding customization on each activity.


## Insight 👀
- Move `RecentAppsThumbnailHidingLifecycleTracker` into lib instead
- Create `RecentAppsThumbnailHidingListener` for thumbnail hiding layout customization
- Make using `FLAG_SECURE` flag is the default implementation for `RecentAppsThumbnailHidingListener`


## PoW (a.k.a Proof Of Work)💪
![20201014_171755](https://user-images.githubusercontent.com/16315358/95976377-9c20f200-0e41-11eb-99e3-bf1abf6406df.gif)

