### PR TITLE
Chore: Disable info log on release build

### DIFF
--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/HardwareKeyWatcher.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/HardwareKeyWatcher.java
@@ -62,7 +62,7 @@ public class HardwareKeyWatcher {
             if (Intent.ACTION_CLOSE_SYSTEM_DIALOGS.equals(action)) {
                 String reason = intent.getStringExtra(SYSTEM_DIALOG_REASON_KEY);
                 if (reason != null) {
-                    Log.i(TAG, "action:" + action + ", reason:" + reason);
+                    logForInfo("action:" + action + ", reason:" + reason);
                     if (mListener != null) {
                         switch (reason) {
                             case SYSTEM_DIALOG_REASON_HOME_KEY:
@@ -87,6 +87,12 @@ public class HardwareKeyWatcher {
     private void logForDebugging(String message) {
         if (BuildConfig.DEBUG) {
             Log.d(TAG, message);
+        }
+    }
+
+    private void logForInfo(String message) {
+        if (BuildConfig.DEBUG) {
+            Log.i(TAG, message);
         }
     }
 }


### PR DESCRIPTION
## What happened 🤔
Show logs for debugging could leak the sensitive information for further attacks


## Insight 👀
- Show the `Log.i` for development mode (BuildConfig.DEBUG) only


## PoW (a.k.a Proof Of Work)💪
N/A