### PR TITLE
[#9] Add support Secured flag on low API devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ dependencies {
 
 > Checkout the custom thumbnail layout sample to see more detail [here](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/res/layout/activity_main.xml#L26-L33)
 
-### Low API support (25 and lowers)
+### Low API support (25 and lower)
 
 The core approach `HardwareKeyWatcher` in this
-lib [doesn't work on API 25 and lowers](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing)
+lib [doesn't work on API 25 and lower](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing)
 . In order to provide an option to cover the hiding app thumbnail on more and more devices, this lib adds support to
 apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE).
 
@@ -83,7 +83,7 @@ apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowM
     ```kotlin
     class MainActivity : RecentAppsThumbnailHidingActivity() {
 
-        // On API 25 and lowers: use FLAG_SECURE
+        // On API 25 and lower: use FLAG_SECURE
         override val enableSecureFlagOnLowApiDevices: Boolean = true
 
         // On API 26 or later: use custom app logo

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Hide app thumbnail in [Android Recent Apps](https://developer.android.com/guide/
 ## Installation
 
 **Step 1.** Add the JitPack repository to your build file
+
 ```groovy
 allprojects {
     repositories {
@@ -28,47 +29,44 @@ dependencies {
 
 ## Usage
 
--
-Register [RecentAppsThumbnailHidingLifecycleTracker](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/App.kt#L9)
-in Application layer.
+- Register [RecentAppsThumbnailHidingLifecycleTracker](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/App.kt#L9)
+  in Application layer.
 
-```kotlin
-class MyApplication : Application() {
+    ```kotlin
+    class MyApplication : Application() {
 
-    override fun onCreate() {
-        super.onCreate()
-        registerActivityLifecycleCallbacks(RecentAppsThumbnailHidingLifecycleTracker())
+        override fun onCreate() {
+            super.onCreate()
+            registerActivityLifecycleCallbacks(RecentAppsThumbnailHidingLifecycleTracker())
+        }
+
     }
+    ```
 
-}
-```
+- Implement [RecentAppsThumbnailHidingListener](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/eaf27aea6ffbbacff65af23a05dd26fb698c5025/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt#L21-L30)
+  in your activity or base activity. By default, the library
+  uses [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) to hide
+  app thumbnail but it will produce side-effects that sometimes the flag can't be set/unset fast enough (not stable) or it
+  blocks the user to take the screenshot.
 
--
-Implement [RecentAppsThumbnailHidingListener](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/eaf27aea6ffbbacff65af23a05dd26fb698c5025/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt#L21-L30)
-in your activity or base activity. By default, the library
-uses [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) to hide
-app thumbnail but it will produce side-effects that sometimes the flag can't be set/unset fast enough (not stable) or it
-blocks the user to take the screenshot.
+    ```kotlin
+    class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
 
-```kotlin
-class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
+    }
+    ```
 
-}
-```
-
-- Or,
-  override [onRecentAppsTriggered](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt#L18-L23)
+- Or, override [onRecentAppsTriggered](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt#L18-L23)
   to show your custom layout for app thumbnail in Recent Apps list.
 
-```kotlin
-class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
+    ```kotlin
+    class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
 
-    override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
-        ivRecentAppThumbnail.visibleOrGone(inRecentAppsMode)
+        override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
+            ivRecentAppThumbnail.visibleOrGone(inRecentAppsMode)
+        }
+
     }
-
-}
-```
+    ```
 
 > Checkout the custom thumbnail layout sample to see more detail [here](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/res/layout/activity_main.xml#L26-L33)
 
@@ -77,25 +75,27 @@ class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
 The core approach `HardwareKeyWatcher` in this
 lib [doesn't work on API 25 and lowers](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing)
 . In order to provide an option to cover the hiding app thumbnail on more and more devices, this lib adds support to
-apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE). This
-support is provided as an *option* and *disabled* by default, to enable it, extend your activity
-to `RecentAppsThumbnailHidingActivity` and override `enableSecureFlagOnLowApiDevices = true`.
+apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE).
 
-```kotlin
-class MainActivity : RecentAppsThumbnailHidingActivity() {
+- This support is provided as an *option* and *disabled* by default, to enable it, extend your activity 
+  to `RecentAppsThumbnailHidingActivity` and override `enableSecureFlagOnLowApiDevices = true`.
 
-    // On API 25 and lowers: use FLAG_SECURE
-    override val enableSecureFlagOnLowApiDevices: Boolean = true
+    ```kotlin
+    class MainActivity : RecentAppsThumbnailHidingActivity() {
 
-    // On API 26 or later: use custom app logo
-    override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
-        ivRecentAppThumbnail.visibleOrGone(inRecentAppsMode)
+        // On API 25 and lowers: use FLAG_SECURE
+        override val enableSecureFlagOnLowApiDevices: Boolean = true
+
+        // On API 26 or later: use custom app logo
+        override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
+            ivRecentAppThumbnail.visibleOrGone(inRecentAppsMode)
+        }
+
     }
+    ```
 
-}
-```
-
-> ⚠️ Note that, besides supporting to hide app thumbnail, this flag will not support to show a custom Recent Apps thumbnail layout, also blocks the user to capture app screenshot.
+> ⚠️ Note that, besides supporting to hide app thumbnail, this flag will not support to
+show a custom Recent Apps thumbnail layout, also blocks the user to capture app screenshot.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://jitpack.io/v/nimblehq/recent-apps-thumbnail-hiding.svg)](https://jitpack.io/#nimblehq/recent-apps-thumbnail-hiding)
 
-Hide app thumbnail in Android Recent Apps
+Hide app thumbnail in [Android Recent Apps](https://developer.android.com/guide/components/activities/recents)
 
 ![20201014_171755](https://user-images.githubusercontent.com/16315358/95976377-9c20f200-0e41-11eb-99e3-bf1abf6406df.gif)
 
@@ -17,7 +17,9 @@ allprojects {
     }
 }
 ```
+
 **Step 2.** Add the dependency
+
 ```groovy
 dependencies {
     implementation 'com.github.nimblehq:recent-apps-thumbnail-hiding:[LATEST_VERSION]'
@@ -26,8 +28,11 @@ dependencies {
 
 ## Usage
 
-- Register `RecentAppsThumbnailHidingLifecycleTracker` in Application layer
-```
+-
+Register [RecentAppsThumbnailHidingLifecycleTracker](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/App.kt#L9)
+in Application layer.
+
+```kotlin
 class MyApplication : Application() {
 
     override fun onCreate() {
@@ -37,15 +42,25 @@ class MyApplication : Application() {
 
 }
 ```
-- Implement [RecentAppsThumbnailHidingListener](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/eaf27aea6ffbbacff65af23a05dd26fb698c5025/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt#L21-L30) in your activity or base activity. By default, the library uses [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) to hide app thumbnail but it will produce a side-effect that sometimes that flag can't be set/unset fast enough or it blocks the user to take the screenshot.
-```
+
+-
+Implement [RecentAppsThumbnailHidingListener](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/eaf27aea6ffbbacff65af23a05dd26fb698c5025/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt#L21-L30)
+in your activity or base activity. By default, the library
+uses [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) to hide
+app thumbnail but it will produce side-effects that sometimes the flag can't be set/unset fast enough (not stable) or it
+blocks the user to take the screenshot.
+
+```kotlin
 class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
 
 }
 ```
-- Or, we could override `onRecentAppsTriggered` to show your custom layout for app thumbnail in Recent Apps list
 
-```
+- Or,
+  override [onRecentAppsTriggered](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt#L18-L23)
+  to show your custom layout for app thumbnail in Recent Apps list.
+
+```kotlin
 class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
 
     override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
@@ -55,10 +70,37 @@ class MainActivity : Activity(), RecentAppsThumbnailHidingListener {
 }
 ```
 
+> Checkout the custom thumbnail layout sample to see more detail [here](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/res/layout/activity_main.xml#L26-L33)
+
+### Low API support (25 and lowers)
+
+The core approach `HardwareKeyWatcher` in this
+lib [doesn't work on API 25 and lowers](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing)
+. In order to provide an option to cover the hiding app thumbnail on more and more devices, this lib adds support to
+apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE). This
+support is provided as an *option* and *disabled* by default, to enable it, extend your activity
+to `RecentAppsThumbnailHidingActivity` and override `enableSecureFlagOnLowApiDevices = true`.
+
+```kotlin
+class MainActivity : RecentAppsThumbnailHidingActivity() {
+
+    // On API 25 and lowers: use FLAG_SECURE
+    override val enableSecureFlagOnLowApiDevices: Boolean = true
+
+    // On API 26 or later: use custom app logo
+    override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
+        ivRecentAppThumbnail.visibleOrGone(inRecentAppsMode)
+    }
+
+}
+```
+
+> ⚠️ Note that, besides supporting to hide app thumbnail, this flag will not support to show a custom Recent Apps thumbnail layout, also blocks the user to capture app screenshot.
+
 ## License
 
-This project is Copyright (c) 2014-2021 Nimble. It is free software,
-and may be redistributed under the terms specified in the [LICENSE] file.
+This project is Copyright (c) 2014-2021 Nimble. It is free software, and may be redistributed under the terms specified
+in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
@@ -4,10 +4,11 @@ import android.app.Activity
 import android.os.Bundle
 import android.view.View.GONE
 import android.view.View.VISIBLE
-import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_main.*
 
-class MainActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
+class MainActivity : RecentAppsThumbnailHidingActivity() {
+
+    override val enableSecureFlagOnLowApiDevices: Boolean = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -9,7 +9,7 @@ abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAp
     protected open val enableSecureFlagOnLowApiDevices: Boolean = false
 
     /**
-     * HardwareKeyWatcher doesn't work on API 25 or lowers,
+     * HardwareKeyWatcher doesn't work on API 25 or lower,
      * allow to use FLAG_SECURE instead to hide app thumbnail.
      */
     val isSecureFlagEnabled: Boolean

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -1,0 +1,21 @@
+package co.nimblehq.recentapps.thumbnailhiding
+
+import android.os.Build
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.appcompat.app.AppCompatActivity
+
+abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
+
+    open val enableSecureFlagOnLowApiDevices: Boolean = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (enableSecureFlagOnLowApiDevices && Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+    }
+}

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -2,7 +2,6 @@ package co.nimblehq.recentapps.thumbnailhiding
 
 import android.os.Build
 import android.os.Bundle
-import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 
 abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
@@ -19,10 +18,7 @@ abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAp
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (isSecureFlagEnabled) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
+            enableSecureFlag(true)
         }
     }
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -7,11 +7,18 @@ import androidx.appcompat.app.AppCompatActivity
 
 abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
 
-    open val enableSecureFlagOnLowApiDevices: Boolean = false
+    protected open val enableSecureFlagOnLowApiDevices: Boolean = false
+
+    /**
+     * HardwareKeyWatcher doesn't work on API 25 or lowers,
+     * allow to use FLAG_SECURE instead to hide app thumbnail.
+     */
+    val isSecureFlagEnabled: Boolean
+        get() = enableSecureFlagOnLowApiDevices && Build.VERSION.SDK_INT < Build.VERSION_CODES.O
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (enableSecureFlagOnLowApiDevices && Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        if (isSecureFlagEnabled) {
             window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -58,13 +58,17 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     override fun onActivityDestroyed(activity: Activity) {
     }
 
+    /**
+     * Only trigger `onRecentAppsTriggered` if the activity
+     * - implements RecentAppsThumbnailHidingListener
+     * - or extends RecentAppsThumbnailHidingActivity with enableSecureFlagOnLowApiDevices disabled
+     */
     private fun Activity.triggerRecentAppsMode(inRecentAppsMode: Boolean) {
         when (val activity = this) {
+            is RecentAppsThumbnailHidingActivity -> if (!activity.isSecureFlagEnabled)
+                activity.onRecentAppsTriggered(activity, inRecentAppsMode)
             is RecentAppsThumbnailHidingListener ->
-                activity.onRecentAppsTriggered(
-                    activity,
-                    inRecentAppsMode
-                )
+                activity.onRecentAppsTriggered(activity, inRecentAppsMode)
         }
     }
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -60,8 +60,8 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
 
     /**
      * Only trigger `onRecentAppsTriggered` if the activity
-     * - implements RecentAppsThumbnailHidingListener
-     * - or extends RecentAppsThumbnailHidingActivity with enableSecureFlagOnLowApiDevices disabled
+     * - implements RecentAppsThumbnailHidingListener or
+     * - extends RecentAppsThumbnailHidingActivity with enableSecureFlagOnLowApiDevices disabled or API 26 (or later)
      */
     private fun Activity.triggerRecentAppsMode(inRecentAppsMode: Boolean) {
         when (val activity = this) {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
@@ -17,8 +17,8 @@ interface RecentAppsThumbnailHidingListener {
         activity.enableSecureFlag(inRecentAppsMode)
     }
 
-    fun Activity.enableSecureFlag(enable: Boolean) {
-        if (enable) {
+    fun Activity.enableSecureFlag(isEnabled: Boolean) {
+        if (isEnabled) {
             window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
@@ -14,11 +14,11 @@ interface RecentAppsThumbnailHidingListener {
         activity: Activity,
         inRecentAppsMode: Boolean
     ) {
-        activity.showOrHideRecentAppThumbnail(inRecentAppsMode)
+        activity.enableSecureFlag(inRecentAppsMode)
     }
 
-    private fun Activity.showOrHideRecentAppThumbnail(inRecentAppsMode: Boolean) {
-        if (inRecentAppsMode) {
+    fun Activity.enableSecureFlag(enable: Boolean) {
+        if (enable) {
             window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE


### PR DESCRIPTION
## What happened 👀

The core approach `HardwareKeyWatcher` in this lib [doesn't work on API 25 and lowers](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing). In order to provide an option to cover the hiding app thumbnail on more and more devices, we will try to add support to apply FLAG_SECURE. Note that, besides supporting to hide app thumbnail, this flag will not support to show a custom app logo in Recent Apps thumbnail, also block the user to capture app screenshot too, so we have to provide this support as an option and disable it by default.


## Insight 📝

- The [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE) flag should be set at `onCreate` event, to manage its usages correctly only in corresponding API levels, we will provide a base activity called **RecentAppsThumbnailHidingActivity**. This activity provides a flag `enableSecureFlagOnLowApiDevices` is disabled by default.
- To avoid logic overlapping between `HardwareKeyWatcher` and `FLAG_SECURE` flag, we should update the condition to trigger `onRecentAppsTriggered` to show custom App Recents layout.


## Proof Of Work 📹

- Before, `HardwareKeyWatcher` approach does not work on API 25 or lowers


https://user-images.githubusercontent.com/16315358/130652468-0ee315ba-65af-4553-bc6f-80fe9f3a8eec.mp4



- After, enabled `enableSecureFlagOnLowApiDevices` flag to use `FLAG_SECURE` flag on API 25 or lowers


https://user-images.githubusercontent.com/16315358/130652592-39c24c8a-3f4d-47a8-b742-cddbcaf07166.mp4


