### PR TITLE
[#8] Add support secured flag on Huawei/Xiaomi devices with custom gesture enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ More testing insight could be found [here](https://docs.google.com/spreadsheets/
 In order to provide an option to cover the hiding app thumbnail on more and more devices,
 this lib adds support to apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE).
 
-This support is provided as an *option* and *disabled* by default, to enable it,
-extend your activity to `RecentAppsThumbnailHidingActivity`
-and override `enableSecureFlagOnLowApiDevices = true`,
-`enableSecureFlagOnDevicesWithCustomGestureNavigation = true`, or both.
+This support is provided as an *option* and *disabled* by default, to enable it:
+
+1. extend your activity to `RecentAppsThumbnailHidingActivity`.
+2. override `enableSecureFlagOnLowApiDevices = true`, `enableSecureFlagOnCustomGestureNavigationDevices = true`, or both.
 
     ```kotlin
     class MainActivity : RecentAppsThumbnailHidingActivity() {
@@ -94,7 +94,7 @@ and override `enableSecureFlagOnLowApiDevices = true`,
         override val enableSecureFlagOnLowApiDevices: Boolean = true
 
         // On some Huawei/Xiaomi devices with custom gesture navigation: use FLAG_SECURE
-        override val enableSecureFlagOnDevicesWithCustomGestureNavigation = true
+        override val enableSecureFlagOnCustomGestureNavigationDevices = true
 
         // The rest: show custom app logo
         override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {

--- a/README.md
+++ b/README.md
@@ -70,23 +70,33 @@ dependencies {
 
 > Checkout the custom thumbnail layout sample to see more detail [here](https://github.com/nimblehq/recent-apps-thumbnail-hiding/blob/master/app/src/main/res/layout/activity_main.xml#L26-L33)
 
-### Low API support (25 and lower)
+### Exceptions handling
 
-The core approach `HardwareKeyWatcher` in this
-lib [doesn't work on API 25 and lower](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing)
-. In order to provide an option to cover the hiding app thumbnail on more and more devices, this lib adds support to
-apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE).
+The core approach `HardwareKeyWatcher` in this lib does not work on all devices.
+There are some failed cases listed as below:
 
-- This support is provided as an *option* and *disabled* by default, to enable it, extend your activity 
-  to `RecentAppsThumbnailHidingActivity` and override `enableSecureFlagOnLowApiDevices = true`.
+- [Low API devices](https://github.com/nimblehq/recent-apps-thumbnail-hiding/issues/9): Android 7.1 (API 25) and lower.
+- [Custom gesture navigation on some Huawei/Xiaomi devices](https://github.com/nimblehq/recent-apps-thumbnail-hiding/issues/8): EMUI or MIUI roms.
+
+More testing insight could be found [here](https://docs.google.com/spreadsheets/d/1znmSllEYHuOhmla7EWFXYeWuv1EZQiVkB9Mibhcj52s/edit?usp=sharing).
+In order to provide an option to cover the hiding app thumbnail on more and more devices,
+this lib adds support to apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE).
+
+This support is provided as an *option* and *disabled* by default, to enable it,
+extend your activity to `RecentAppsThumbnailHidingActivity`
+and override `enableSecureFlagOnLowApiDevices = true`,
+`enableSecureFlagOnDevicesWithCustomGestureNavigation = true`, or both.
 
     ```kotlin
     class MainActivity : RecentAppsThumbnailHidingActivity() {
 
-        // On API 25 and lower: use FLAG_SECURE
+        // On devices with API 25 and lower: use FLAG_SECURE
         override val enableSecureFlagOnLowApiDevices: Boolean = true
 
-        // On API 26 or later: use custom app logo
+        // On some Huawei/Xiaomi devices with custom gesture navigation: use FLAG_SECURE
+        override val enableSecureFlagOnDevicesWithCustomGestureNavigation = true
+
+        // The rest: show custom app logo
         override fun onRecentAppsTriggered(activity: Activity, inRecentAppsMode: Boolean) {
             ivRecentAppThumbnail.visibleOrGone(inRecentAppsMode)
         }
@@ -94,13 +104,14 @@ apply [FLAG_SECURE](https://developer.android.com/reference/android/view/WindowM
     }
     ```
 
-> ⚠️ Note that, besides supporting to hide app thumbnail, this flag will not support to
-show a custom Recent Apps thumbnail layout, also blocks the user to capture app screenshot.
+> ⚠️ Note that, besides supporting to hide app thumbnail, this flag
+**will not support to show a custom Recent Apps thumbnail layout**,
+also **blocks the user to capture app screenshot**.
 
 ## License
 
-This project is Copyright (c) 2014-2021 Nimble. It is free software, and may be redistributed under the terms specified
-in the [LICENSE] file.
+This project is Copyright (c) 2014-2021 Nimble. It is free software,
+and may be redistributed under the terms specified in the [LICENSE] file.
 
 [LICENSE]: /LICENSE
 

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
@@ -10,6 +10,8 @@ class MainActivity : RecentAppsThumbnailHidingActivity() {
 
     override val enableSecureFlagOnLowApiDevices: Boolean = true
 
+    override val enableSecureFlagOnDevicesWithCustomGestureNavigation: Boolean = true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)

--- a/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
+++ b/app/src/main/java/co/nimblehq/recentapps/thumbnailhiding/MainActivity.kt
@@ -10,7 +10,7 @@ class MainActivity : RecentAppsThumbnailHidingActivity() {
 
     override val enableSecureFlagOnLowApiDevices: Boolean = true
 
-    override val enableSecureFlagOnDevicesWithCustomGestureNavigation: Boolean = true
+    override val enableSecureFlagOnCustomGestureNavigationDevices: Boolean = true
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -20,17 +20,17 @@ abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(),
      * HardwareKeyWatcher doesn't work on some Xiaomi or Huawei devices with custom gesture navigation enabled,
      * allow to use FLAG_SECURE instead to hide app thumbnail.
      */
-    open val enableSecureFlagOnDevicesWithCustomGestureNavigation: Boolean = false
+    open val enableSecureFlagOnCustomGestureNavigationDevices: Boolean = false
 
     private val isSecureFlagOnLowApiDevicesEnabled: Boolean
         get() = enableSecureFlagOnLowApiDevices && Build.VERSION.SDK_INT < Build.VERSION_CODES.O
 
-    private val isSecureFlagOnDevicesWithCustomGestureNavigationEnabled: Boolean
-        get() = enableSecureFlagOnDevicesWithCustomGestureNavigation && isGestureEnabled(this)
+    private val isSecureFlagOnCustomGestureNavigationDevicesEnabled: Boolean
+        get() = enableSecureFlagOnCustomGestureNavigationDevices && isGestureEnabled(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (isSecureFlagOnLowApiDevicesEnabled || isSecureFlagOnDevicesWithCustomGestureNavigationEnabled) {
+        if (isSecureFlagOnLowApiDevicesEnabled || isSecureFlagOnCustomGestureNavigationDevicesEnabled) {
             enableSecureFlag(true)
         }
     }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -1,7 +1,9 @@
 package co.nimblehq.recentapps.thumbnailhiding
 
+import android.app.Activity
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import co.nimblehq.recentapps.thumbnailhiding.navbar.NavigationBarObserver
 
@@ -22,5 +24,18 @@ abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(),
         if (isSecureFlagEnabled || !NavigationBarObserver.isNavigationBarShowing(this)) {
             enableSecureFlag(true)
         }
+    }
+}
+
+fun Activity.enableSecureFlag(isEnabled: Boolean) {
+    if (isEnabled) {
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+    } else {
+        window.clearFlags(
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
     }
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -5,23 +5,32 @@ import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
-import co.nimblehq.recentapps.thumbnailhiding.navbar.NavigationBarObserver
+import co.nimblehq.recentapps.thumbnailhiding.navbar.NavigationBarObserver.isGestureEnabled
 
 abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(),
     RecentAppsThumbnailHidingListener {
-
-    protected open val enableSecureFlagOnLowApiDevices: Boolean = false
 
     /**
      * HardwareKeyWatcher doesn't work on API 25 or lower,
      * allow to use FLAG_SECURE instead to hide app thumbnail.
      */
-    val isSecureFlagEnabled: Boolean
+    open val enableSecureFlagOnLowApiDevices: Boolean = false
+
+    /**
+     * HardwareKeyWatcher doesn't work on some Xiaomi or Huawei devices with custom gesture navigation enabled,
+     * allow to use FLAG_SECURE instead to hide app thumbnail.
+     */
+    open val enableSecureFlagOnDevicesWithCustomGestureNavigation: Boolean = false
+
+    private val isSecureFlagOnLowApiDevicesEnabled: Boolean
         get() = enableSecureFlagOnLowApiDevices && Build.VERSION.SDK_INT < Build.VERSION_CODES.O
+
+    private val isSecureFlagOnDevicesWithCustomGestureNavigationEnabled: Boolean
+        get() = enableSecureFlagOnDevicesWithCustomGestureNavigation && isGestureEnabled(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (isSecureFlagEnabled || NavigationBarObserver.isNavigationGestureEnabled(this)) {
+        if (isSecureFlagOnLowApiDevicesEnabled || isSecureFlagOnDevicesWithCustomGestureNavigationEnabled) {
             enableSecureFlag(true)
         }
     }
@@ -38,4 +47,9 @@ fun Activity.enableSecureFlag(isEnabled: Boolean) {
             WindowManager.LayoutParams.FLAG_SECURE
         )
     }
+}
+
+fun Activity.isSecureFlagEnabled(): Boolean {
+    val flags = window.attributes.flags
+    return (flags and WindowManager.LayoutParams.FLAG_SECURE) != 0
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -21,7 +21,7 @@ abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(),
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (isSecureFlagEnabled || !NavigationBarObserver.isNavigationBarShowing(this)) {
+        if (isSecureFlagEnabled || NavigationBarObserver.isNavigationGestureEnabled(this)) {
             enableSecureFlag(true)
         }
     }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingActivity.kt
@@ -3,8 +3,10 @@ package co.nimblehq.recentapps.thumbnailhiding
 import android.os.Build
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import co.nimblehq.recentapps.thumbnailhiding.navbar.NavigationBarObserver
 
-abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAppsThumbnailHidingListener {
+abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(),
+    RecentAppsThumbnailHidingListener {
 
     protected open val enableSecureFlagOnLowApiDevices: Boolean = false
 
@@ -17,7 +19,7 @@ abstract class RecentAppsThumbnailHidingActivity : AppCompatActivity(), RecentAp
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (isSecureFlagEnabled) {
+        if (isSecureFlagEnabled || !NavigationBarObserver.isNavigationBarShowing(this)) {
             enableSecureFlag(true)
         }
     }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -22,8 +22,8 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
                 navigationBarObserver = null
                 navigationBarListener = null
             }
-            navigationBarListener = OnNavigationBarListener { inGestureNavigationMode ->
-                activity.enableSecureFlag(!inGestureNavigationMode)
+            navigationBarListener = OnNavigationBarListener { isGestureEnabled ->
+                activity.enableSecureFlag(isGestureEnabled)
             }
             navigationBarObserver = NavigationBarObserver.getInstance().apply {
                 register(activity)

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -17,14 +17,16 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (NavigationBarObserver.isAvailable()) {
             if (navigationBarObserver?.activityContext != activity) {
-                navigationBarObserver?.unregister()
-                navigationBarObserver?.removeOnNavigationBarListener(navigationBarListener)
+                navigationBarObserver?.run {
+                    unregister()
+                    removeOnNavigationBarListener(navigationBarListener)
+                }
                 navigationBarObserver = null
                 navigationBarListener = null
             }
             navigationBarListener = OnNavigationBarListener { isGestureEnabled ->
                 if (activity is RecentAppsThumbnailHidingActivity
-                    && activity.enableSecureFlagOnDevicesWithCustomGestureNavigation
+                    && activity.enableSecureFlagOnCustomGestureNavigationDevices
                 ) {
                     activity.enableSecureFlag(isGestureEnabled)
                 }
@@ -82,8 +84,10 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
 
     override fun onActivityDestroyed(activity: Activity) {
         if (NavigationBarObserver.isAvailable() && navigationBarObserver?.activityContext == activity) {
-            navigationBarObserver?.unregister()
-            navigationBarObserver?.removeOnNavigationBarListener(navigationBarListener)
+            navigationBarObserver?.run {
+                unregister()
+                removeOnNavigationBarListener(navigationBarListener)
+            }
             navigationBarObserver = null
             navigationBarListener = null
         }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingLifecycleTracker.kt
@@ -23,7 +23,11 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
                 navigationBarListener = null
             }
             navigationBarListener = OnNavigationBarListener { isGestureEnabled ->
-                activity.enableSecureFlag(isGestureEnabled)
+                if (activity is RecentAppsThumbnailHidingActivity
+                    && activity.enableSecureFlagOnDevicesWithCustomGestureNavigation
+                ) {
+                    activity.enableSecureFlag(isGestureEnabled)
+                }
             }
             navigationBarObserver = NavigationBarObserver.getInstance().apply {
                 register(activity)
@@ -92,7 +96,7 @@ class RecentAppsThumbnailHidingLifecycleTracker : Application.ActivityLifecycleC
      */
     private fun Activity.triggerRecentAppsMode(inRecentAppsMode: Boolean) {
         when (val activity = this) {
-            is RecentAppsThumbnailHidingActivity -> if (!activity.isSecureFlagEnabled)
+            is RecentAppsThumbnailHidingActivity -> if (!activity.isSecureFlagEnabled())
                 activity.onRecentAppsTriggered(activity, inRecentAppsMode)
             is RecentAppsThumbnailHidingListener ->
                 activity.onRecentAppsTriggered(activity, inRecentAppsMode)

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
@@ -16,17 +16,17 @@ interface RecentAppsThumbnailHidingListener {
     ) {
         activity.enableSecureFlag(inRecentAppsMode)
     }
+}
 
-    fun Activity.enableSecureFlag(isEnabled: Boolean) {
-        if (isEnabled) {
-            window.setFlags(
+fun Activity.enableSecureFlag(isEnabled: Boolean) {
+    if (isEnabled) {
+        window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE
-            )
-        } else {
-            window.clearFlags(
+        )
+    } else {
+        window.clearFlags(
                 WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
+        )
     }
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/RecentAppsThumbnailHidingListener.kt
@@ -1,7 +1,6 @@
 package co.nimblehq.recentapps.thumbnailhiding
 
 import android.app.Activity
-import android.view.WindowManager
 
 interface RecentAppsThumbnailHidingListener {
 
@@ -15,18 +14,5 @@ interface RecentAppsThumbnailHidingListener {
         inRecentAppsMode: Boolean
     ) {
         activity.enableSecureFlag(inRecentAppsMode)
-    }
-}
-
-fun Activity.enableSecureFlag(isEnabled: Boolean) {
-    if (isEnabled) {
-        window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-        )
-    } else {
-        window.clearFlags(
-                WindowManager.LayoutParams.FLAG_SECURE
-        )
     }
 }

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
@@ -28,6 +28,8 @@ public final class NavigationBarObserver extends ContentObserver {
     static final String IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW = "navigationbar_is_min";
 
     private ArrayList<OnNavigationBarListener> mListeners;
+    // FIXME get rid of temporary activityContext
+    private Context activityContext;
     private Context context;
     private Boolean mIsRegister = false;
 
@@ -40,6 +42,7 @@ public final class NavigationBarObserver extends ContentObserver {
     }
 
     public void register(Context context) {
+        this.activityContext = context;
         this.context = context.getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 &&
             context.getContentResolver() != null && !mIsRegister) {
@@ -58,6 +61,10 @@ public final class NavigationBarObserver extends ContentObserver {
                 mIsRegister = true;
             }
         }
+    }
+
+    public void unregister() {
+        context.getContentResolver().unregisterContentObserver(this);
     }
 
     @Override
@@ -103,6 +110,14 @@ public final class NavigationBarObserver extends ContentObserver {
             return;
         }
         mListeners.remove(listener);
+    }
+
+    public Context getActivityContext() {
+        return activityContext;
+    }
+
+    public static boolean isAvailable() {
+        return OSUtils.isMIUI() || OSUtils.isEMUI();
     }
 
     private static class NavigationBarObserverInstance {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
@@ -1,0 +1,112 @@
+package co.nimblehq.recentapps.thumbnailhiding.navbar;
+
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.Settings;
+
+import java.util.ArrayList;
+
+/**
+ * copy from https://github.com/gyf-dev/ImmersionBar.
+ * 导航栏显示隐藏处理，目前只支持emui和miui带有导航栏的手机
+ *
+ * @author geyifeng
+ * @date 2019/4/10 6:02 PM
+ */
+public final class NavigationBarObserver extends ContentObserver {
+    /**
+     * MIUI导航栏显示隐藏标识位
+     */
+    static final String IMMERSION_MIUI_NAVIGATION_BAR_HIDE_SHOW = "force_fsg_nav_bar";
+    /**
+     * EMUI导航栏显示隐藏标识位
+     */
+    static final String IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW = "navigationbar_is_min";
+
+    private ArrayList<OnNavigationBarListener> mListeners;
+    private Context context;
+    private Boolean mIsRegister = false;
+
+    public static NavigationBarObserver getInstance() {
+        return NavigationBarObserverInstance.INSTANCE;
+    }
+
+    private NavigationBarObserver() {
+        super(new Handler(Looper.getMainLooper()));
+    }
+
+    public void register(Context context) {
+        this.context = context.getApplicationContext();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 &&
+            context.getContentResolver() != null && !mIsRegister) {
+            Uri uri = null;
+            if (OSUtils.isMIUI()) {
+                uri = Settings.Global.getUriFor(IMMERSION_MIUI_NAVIGATION_BAR_HIDE_SHOW);
+            } else if (OSUtils.isEMUI()) {
+                if (OSUtils.isEMUI3_x() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                    uri = Settings.System.getUriFor(IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW);
+                } else {
+                    uri = Settings.Global.getUriFor(IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW);
+                }
+            }
+            if (uri != null) {
+                context.getContentResolver().registerContentObserver(uri, true, this);
+                mIsRegister = true;
+            }
+        }
+    }
+
+    @Override
+    public void onChange(boolean selfChange) {
+        super.onChange(selfChange);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && context != null && context.getContentResolver() != null
+            && mListeners != null && !mListeners.isEmpty()) {
+            int show = 0;
+            if (OSUtils.isMIUI()) {
+                show = Settings.Global.getInt(context.getContentResolver(), IMMERSION_MIUI_NAVIGATION_BAR_HIDE_SHOW, 0);
+            } else if (OSUtils.isEMUI()) {
+                if (OSUtils.isEMUI3_x() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                    show = Settings.System.getInt(context.getContentResolver(), IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW, 0);
+                } else {
+                    show = Settings.Global.getInt(context.getContentResolver(), IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW, 0);
+                }
+            }
+            for (OnNavigationBarListener onNavigationBarListener : mListeners) {
+                onNavigationBarListener.onNavigationBarChange(show != 1);
+            }
+        }
+    }
+
+    public void addOnNavigationBarListener(OnNavigationBarListener listener) {
+        if (listener == null) {
+            return;
+        }
+        if (mListeners == null) {
+            mListeners = new ArrayList<>();
+        }
+        if (!mListeners.contains(listener)) {
+            mListeners.add(listener);
+        }
+    }
+
+    public void removeOnNavigationBarListener(OnNavigationBarListener listener) {
+        if (mIsRegister) {
+            context.getContentResolver().unregisterContentObserver(this);
+            mIsRegister = false;
+        }
+        this.context = null;
+        if (listener == null || mListeners == null) {
+            return;
+        }
+        mListeners.remove(listener);
+    }
+
+    private static class NavigationBarObserverInstance {
+        private static final NavigationBarObserver INSTANCE = new NavigationBarObserver();
+    }
+
+}

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
@@ -45,7 +45,7 @@ public final class NavigationBarObserver extends ContentObserver {
         this.activityContext = context;
         this.context = context.getApplicationContext();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 &&
-            context.getContentResolver() != null && !mIsRegister) {
+                context.getContentResolver() != null && !mIsRegister) {
             Uri uri = null;
             if (OSUtils.isMIUI()) {
                 uri = Settings.Global.getUriFor(IMMERSION_MIUI_NAVIGATION_BAR_HIDE_SHOW);
@@ -70,20 +70,10 @@ public final class NavigationBarObserver extends ContentObserver {
     @Override
     public void onChange(boolean selfChange) {
         super.onChange(selfChange);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && context != null && context.getContentResolver() != null
-            && mListeners != null && !mListeners.isEmpty()) {
-            int show = 0;
-            if (OSUtils.isMIUI()) {
-                show = Settings.Global.getInt(context.getContentResolver(), IMMERSION_MIUI_NAVIGATION_BAR_HIDE_SHOW, 0);
-            } else if (OSUtils.isEMUI()) {
-                if (OSUtils.isEMUI3_x() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                    show = Settings.System.getInt(context.getContentResolver(), IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW, 0);
-                } else {
-                    show = Settings.Global.getInt(context.getContentResolver(), IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW, 0);
-                }
-            }
+        if (mListeners != null && !mListeners.isEmpty()) {
+            boolean show = isNavigationBarShowing(context);
             for (OnNavigationBarListener onNavigationBarListener : mListeners) {
-                onNavigationBarListener.onNavigationBarChange(show != 1);
+                onNavigationBarListener.onNavigationBarChange(show);
             }
         }
     }
@@ -117,7 +107,24 @@ public final class NavigationBarObserver extends ContentObserver {
     }
 
     public static boolean isAvailable() {
-        return OSUtils.isMIUI() || OSUtils.isEMUI();
+        return (OSUtils.isMIUI() || OSUtils.isEMUI()) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
+    }
+
+    public static boolean isNavigationBarShowing(Context context) {
+        int show = 0;
+        Context appContext = context.getApplicationContext();
+        if (isAvailable() && appContext != null && appContext.getContentResolver() != null) {
+            if (OSUtils.isMIUI()) {
+                show = Settings.Global.getInt(appContext.getContentResolver(), IMMERSION_MIUI_NAVIGATION_BAR_HIDE_SHOW, 0);
+            } else if (OSUtils.isEMUI()) {
+                if (OSUtils.isEMUI3_x() || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                    show = Settings.System.getInt(appContext.getContentResolver(), IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW, 0);
+                } else {
+                    show = Settings.Global.getInt(appContext.getContentResolver(), IMMERSION_EMUI_NAVIGATION_BAR_HIDE_SHOW, 0);
+                }
+            }
+        }
+        return show != 1;
     }
 
     private static class NavigationBarObserverInstance {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
@@ -71,9 +71,9 @@ public final class NavigationBarObserver extends ContentObserver {
     public void onChange(boolean selfChange) {
         super.onChange(selfChange);
         if (mListeners != null && !mListeners.isEmpty()) {
-            boolean show = isNavigationBarShowing(context);
+            boolean enabled = isNavigationGestureEnabled(context);
             for (OnNavigationBarListener onNavigationBarListener : mListeners) {
-                onNavigationBarListener.onNavigationBarChange(show);
+                onNavigationBarListener.onNavigationBarChange(enabled);
             }
         }
     }
@@ -110,7 +110,7 @@ public final class NavigationBarObserver extends ContentObserver {
         return (OSUtils.isMIUI() || OSUtils.isEMUI()) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
     }
 
-    public static boolean isNavigationBarShowing(Context context) {
+    public static boolean isNavigationGestureEnabled(Context context) {
         int show = 0;
         Context appContext = context.getApplicationContext();
         if (isAvailable() && appContext != null && appContext.getContentResolver() != null) {
@@ -124,7 +124,7 @@ public final class NavigationBarObserver extends ContentObserver {
                 }
             }
         }
-        return show != 1;
+        return show != 0;
     }
 
     private static class NavigationBarObserverInstance {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/NavigationBarObserver.java
@@ -71,7 +71,7 @@ public final class NavigationBarObserver extends ContentObserver {
     public void onChange(boolean selfChange) {
         super.onChange(selfChange);
         if (mListeners != null && !mListeners.isEmpty()) {
-            boolean enabled = isNavigationGestureEnabled(context);
+            boolean enabled = isGestureEnabled(context);
             for (OnNavigationBarListener onNavigationBarListener : mListeners) {
                 onNavigationBarListener.onNavigationBarChange(enabled);
             }
@@ -110,7 +110,7 @@ public final class NavigationBarObserver extends ContentObserver {
         return (OSUtils.isMIUI() || OSUtils.isEMUI()) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1;
     }
 
-    public static boolean isNavigationGestureEnabled(Context context) {
+    public static boolean isGestureEnabled(Context context) {
         int show = 0;
         Context appContext = context.getApplicationContext();
         if (isAvailable() && appContext != null && appContext.getContentResolver() != null) {

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/OSUtils.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/OSUtils.java
@@ -1,0 +1,101 @@
+package co.nimblehq.recentapps.thumbnailhiding.navbar;
+
+import android.annotation.SuppressLint;
+import android.text.TextUtils;
+
+import java.lang.reflect.Method;
+
+/**
+ * copy from https://github.com/gyf-dev/ImmersionBar.
+ * 手机系统判断
+ *
+ * @author geyifeng
+ * @date 2017/4/18
+ */
+public class OSUtils {
+
+    private static final String KEY_MIUI_VERSION_NAME = "ro.miui.ui.version.name";
+    private static final String KEY_EMUI_VERSION_NAME = "ro.build.version.emui";
+    private static final String KEY_DISPLAY = "ro.build.display.id";
+
+    /**
+     * 判断是否为miui
+     * Is miui boolean.
+     *
+     * @return the boolean
+     */
+    public static boolean isMIUI() {
+        String property = getSystemProperty(KEY_MIUI_VERSION_NAME, "");
+        return !TextUtils.isEmpty(property);
+    }
+
+    /**
+     * 判断是否为emui
+     * Is emui boolean.
+     *
+     * @return the boolean
+     */
+    public static boolean isEMUI() {
+        String property = getSystemProperty(KEY_EMUI_VERSION_NAME, "");
+        return !TextUtils.isEmpty(property);
+    }
+
+    /**
+     * 得到emui的版本
+     * Gets emui version.
+     *
+     * @return the emui version
+     */
+    public static String getEMUIVersion() {
+        return isEMUI() ? getSystemProperty(KEY_EMUI_VERSION_NAME, "") : "";
+    }
+
+    /**
+     * 判断是否为emui3.1版本
+     * Is emui 3 1 boolean.
+     *
+     * @return the boolean
+     */
+    public static boolean isEMUI3_1() {
+        String property = getEMUIVersion();
+        if ("EmotionUI 3".equals(property) || property.contains("EmotionUI_3.1")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 判断是否为emui3.0版本
+     * Is emui 3 1 boolean.
+     *
+     * @return the boolean
+     */
+    public static boolean isEMUI3_0() {
+        String property = getEMUIVersion();
+        if (property.contains("EmotionUI_3.0")) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 判断是否为emui3.x版本
+     * Is emui 3 x boolean.
+     *
+     * @return the boolean
+     */
+    public static boolean isEMUI3_x() {
+        return OSUtils.isEMUI3_0() || OSUtils.isEMUI3_1();
+    }
+
+    private static String getSystemProperty(String key, String defaultValue) {
+        try {
+            @SuppressLint("PrivateApi") Class<?> clz = Class.forName("android.os.SystemProperties");
+            Method method = clz.getMethod("get", String.class, String.class);
+            return (String) method.invoke(clz, key, defaultValue);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return defaultValue;
+    }
+}

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/OnNavigationBarListener.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/OnNavigationBarListener.java
@@ -1,0 +1,17 @@
+package co.nimblehq.recentapps.thumbnailhiding.navbar;
+
+/**
+ * copy from https://github.com/gyf-dev/ImmersionBar.
+ * The interface On navigation bar listener.
+ *
+ * @author geyifeng
+ * @date 2019 /4/10 6:12 PM
+ */
+public interface OnNavigationBarListener {
+    /**
+     * On navigation bar change.
+     *
+     * @param show the show
+     */
+    void onNavigationBarChange(boolean show);
+}

--- a/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/OnNavigationBarListener.java
+++ b/lib/src/main/java/co/nimblehq/recentapps/thumbnailhiding/navbar/OnNavigationBarListener.java
@@ -11,7 +11,7 @@ public interface OnNavigationBarListener {
     /**
      * On navigation bar change.
      *
-     * @param show the show
+     * @param isGestureEnabled
      */
-    void onNavigationBarChange(boolean show);
+    void onNavigationBarChange(boolean isGestureEnabled);
 }


### PR DESCRIPTION
Solves #8 

## What happened 👀

The lib does not work on some Huawei/Xiaomi devices with custom gesture navigation. There should be a way to hide app thumbnail in Recent Apps to cover this case.


## Insight 📝

- After researching, I found [a way to observe the custom gesture navigation enabled in Settings on Huawei and Xiaomi ROMs](https://github.com/nimblehq/recent-apps-thumbnail-hiding/pull/7/commits/18e09fcefa8b2e189984283cd60cd7e12ab4af10) to apply using `FLAG_SECURE`. 
- The `NavigationBarObserver` only observe when the user change the navigation mode in Settings, so we need to define a [isGestureEnabled](https://github.com/nimblehq/recent-apps-thumbnail-hiding/pull/7/files#diff-de8047fcc35012b48dda2e033b75df73377162d6f2e9bfa4fde930c18440be0cR113-R128) check to apply using `FLAG_SECURE` when opening the app in custom gesture navigation mode.
- We also provide a new flag [enableSecureFlagOnDevicesWithCustomGestureNavigation](https://github.com/nimblehq/recent-apps-thumbnail-hiding/pull/7/files#diff-bcfd0869490da3a7967fcc0c954d9d5a813401c526395c8af72fab507bef7d58R23) beside `enableSecureFlagOnLowApiDevices` in `RecentAppsThumbnailHidingActivity` to manually turn on each cases to cover missed cases by using `FLAG_SECURE` ✅ .

## Proof Of Work 📹

- Huawei Mate 30 Pro - EMUI 10

https://user-images.githubusercontent.com/16315358/131106880-e3d31c63-0f8d-4361-8730-a7efed53a8d9.mp4

- Nova 5T - EMUI 10

https://user-images.githubusercontent.com/16315358/131238660-4c249cb0-e73f-47c2-9e42-3fd953f0f55a.mp4

